### PR TITLE
Fix parsing of budget and deadline in logs

### DIFF
--- a/scripts/log_parser/parse_experiment_log.py
+++ b/scripts/log_parser/parse_experiment_log.py
@@ -63,11 +63,11 @@ PATTERNS = [
         type=Workflow,
         set_values={}),
     log_parser.Pattern(
-        regex=r'budget = (?P<budget>\d+.\d+)',
+        regex=r'budget = (?P<budget>.*$)',
         type=ExperimentSettingsWithId,
         set_values={'id': 0, 'deadline': None, 'vm_cost_per_hour': 1}),
     log_parser.Pattern(
-        regex=r'deadline = (?P<deadline>\d+.\d+)',
+        regex=r'deadline = (?P<deadline>.*$)',
         type=ExperimentSettingsWithId,
         set_values={'id': 0, 'budget': None, 'vm_cost_per_hour': None}),
     log_parser.Pattern(


### PR DESCRIPTION
Couldn't parse exponential notation correctly because too simple a regex
was used. Fix by grabbing the rest of the line (`.*$` instead of
`\d+.\d+`) and letting pythons `float()` function do the real parsing.

[ Sorry if the volume of pull requests was annoying, this is the last one for a while I promise! ]
