### PR TITLE
Fixed checking whether vm is free when it is terminated

### DIFF
--- a/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
+++ b/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
@@ -1,11 +1,5 @@
 package cws.core.scheduler;
 
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.TreeMap;
-
 import cws.core.VM;
 import cws.core.WorkflowEngine;
 import cws.core.cloudsim.CloudSimWrapper;
@@ -13,6 +7,12 @@ import cws.core.engine.Environment;
 import cws.core.jobs.Job;
 import cws.core.storage.StorageManager;
 import cws.core.storage.cache.VMCacheManager;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 /**
  * {@link WorkflowAwareEnsembleScheduler} implementation that is also aware of the underlying storage and schedules jobs
@@ -65,7 +65,7 @@ public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicSchedul
                 }
                 List<VM> allVms = engine.getAvailableVMs();
                 for (VM vm : allVms) {
-                    if (!vm.isFree()) {
+                    if (!vm.isTerminated() && !vm.isFree()) {
                         double t = vm.getPredictedReleaseTime(storageManager, environment, cacheManager);
                         double estimatedJobFinish = runtimePredictioner.getPredictedRuntime(job.getTask(), vm) + t;
                         if (estimatedJobFinish < bestFinishTime) {


### PR DESCRIPTION
Why?
Because:
```
Exception in thread "main" java.lang.IllegalStateException: Attempted to determine whether terminated VM is free. Check for termination first.
	at cws.core.VM.isFree(VM.java:113)
	at cws.core.scheduler.WorkflowAndLocalityAwareEnsembleScheduler.scheduleJobsWithTheSamePriority(Unknown Source)
	at cws.core.scheduler.WorkflowAndLocalityAwareEnsembleScheduler.scheduleJobs(Unknown Source)
	at cws.core.WorkflowEngine.jobFinished(WorkflowEngine.java:197)
	at cws.core.WorkflowEngine.processEvent(WorkflowEngine.java:71)
	at cws.core.cloudsim.CWSSimEntity.processEvent(CWSSimEntity.java:56)
	at org.cloudbus.cloudsim.core.SimEntity.run(SimEntity.java:406)
	at org.cloudbus.cloudsim.core.CloudSim.runClockTick(CloudSim.java:518)
	at org.cloudbus.cloudsim.core.CloudSim.run(CloudSim.java:882)
	at org.cloudbus.cloudsim.core.CloudSim.startSimulation(CloudSim.java:188)
	at cws.core.cloudsim.CloudSimWrapper.startSimulation(CloudSimWrapper.java:69)
	at cws.core.algorithms.DynamicAlgorithm.simulateInternal(DynamicAlgorithm.java:35)
	at cws.core.algorithms.Algorithm.simulate(Algorithm.java:53)
	at cws.core.simulation.Simulation.runTest(Simulation.java:425)
	at cws.core.simulation.Simulation.main(Simulation.java:224)
```

Imports reorder is due to the automatic formatter