### PR TITLE
Environment class refactoring

### DIFF
--- a/src/cws/core/VM.java
+++ b/src/cws/core/VM.java
@@ -1,5 +1,9 @@
 package cws.core;
 
+import java.util.*;
+
+import com.google.common.base.Preconditions;
+
 import cws.core.cloudsim.CWSSimEntity;
 import cws.core.cloudsim.CWSSimEvent;
 import cws.core.cloudsim.CloudSimWrapper;
@@ -9,19 +13,6 @@ import cws.core.exception.UnknownWorkflowEventException;
 import cws.core.jobs.Job;
 import cws.core.jobs.RuntimeDistribution;
 import cws.core.storage.StorageManager;
-import cws.core.storage.cache.VMCacheManager;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Set;
-
-import com.google.common.base.Preconditions;
 
 /**
  * A VM is a virtual machine that executes Jobs.
@@ -184,8 +175,8 @@ public class VM extends CWSSimEntity {
             }
         } else {
             if (ev.getTag() == WorkflowEvent.VM_LAUNCH || ev.getTag() == WorkflowEvent.JOB_SUBMIT) {
-                throw new IllegalStateException("Attempted to send launch or submit event to terminated VM:"
-                        + this.getId());
+                throw new IllegalStateException(
+                        "Attempted to send launch or submit event to terminated VM:" + this.getId());
             }
         }
     }
@@ -270,11 +261,10 @@ public class VM extends CWSSimEntity {
             job.setResult(Job.Result.SUCCESS);
         }
 
-        getCloudsim()
-                .log(String
-                        .format("Starting computational part of job %s (task_id = %s, workflow = %s) on VM %s. Will finish in %f",
-                                job.getID(), job.getTask().getId(), job.getDAGJob().getDAG().getId(), job.getVM()
-                                        .getId(), actualRuntime));
+        getCloudsim().log(String.format(
+                "Starting computational part of job %s (task_id = %s, workflow = %s) on VM %s. Will finish in %f",
+                job.getID(), job.getTask().getId(), job.getDAGJob().getDAG().getId(), job.getVM().getId(),
+                actualRuntime));
 
         getCloudsim().send(getId(), getId(), actualRuntime, WorkflowEvent.JOB_FINISHED, job);
 
@@ -342,9 +332,10 @@ public class VM extends CWSSimEntity {
             throw new RuntimeException("Non-running job finished:" + job.getID());
         }
 
-        String msg = String.format("Computational part of job %s "
-                + "(task_id = %s, workflow = %s, retry = %s) on VM %s finished", job.getID(), job.getTask().getId(),
-                job.getDAGJob().getDAG().getId(), job.isRetry(), job.getVM().getId());
+        String msg = String.format(
+                "Computational part of job %s " + "(task_id = %s, workflow = %s, retry = %s) on VM %s finished",
+                job.getID(), job.getTask().getId(), job.getDAGJob().getDAG().getId(), job.isRetry(),
+                job.getVM().getId());
         getCloudsim().log(msg);
 
         getCloudsim().send(getId(), getCloudsim().getEntityId("StorageManager"), 0.0,
@@ -501,9 +492,9 @@ public class VM extends CWSSimEntity {
 
     /**
      * Returns the time from now when this VM is predicted to have at least one idle core. This executes in the context
-     * of {@link Environment}, {@link StorageManager} and {@link VMCacheManager}.
+     * of {@link Environment} and {@link StorageManager}}.
      */
-    public double getPredictedReleaseTime(StorageManager sm, Environment env, VMCacheManager cacheManager) {
+    public double getPredictedReleaseTime(StorageManager sm, Environment env) {
         final List<Double> taskRuntimes = new ArrayList<>();
         for (final Job job : this.runningJobs) {
             taskRuntimes.add(getPredictedRemainingRuntime(job, sm, env));
@@ -516,16 +507,15 @@ public class VM extends CWSSimEntity {
         return predictedReleaseTime > 0 ? predictedReleaseTime : 0;
     }
 
-    private double getPredictedRemainingRuntime(final Job job, final StorageManager sm, final Environment env){
-        if(this.writeIntervals.containsKey(job)){ // job is in output files transfer phase
+    private double getPredictedRemainingRuntime(final Job job, final StorageManager sm, final Environment env) {
+        if (this.writeIntervals.containsKey(job)) { // job is in output files transfer phase
             return sm.getOutputTransferTimeEstimation(job.getTask(), this) - this.writeIntervals.get(job).getDuration();
         } else if (this.computationIntervals.containsKey(job)) { // job is in computation phase
             return sm.getOutputTransferTimeEstimation(job.getTask(), this)
                     + env.getComputationPredictedRuntime(job.getTask())
                     - this.computationIntervals.get(job).getDuration();
-        } else if (this.readIntervals.containsKey(job)){ // job is in input files transfer phase
-            return sm.getTotalTransferTimeEstimation(job.getTask(), this)
-                    - this.readIntervals.get(job).getDuration()
+        } else if (this.readIntervals.containsKey(job)) { // job is in input files transfer phase
+            return sm.getTotalTransferTimeEstimation(job.getTask(), this) - this.readIntervals.get(job).getDuration()
                     + env.getComputationPredictedRuntime(job.getTask());
         } else { // job is waiting in queue
             return sm.getTotalTransferTimeEstimation(job.getTask(), this)

--- a/src/cws/core/VM.java
+++ b/src/cws/core/VM.java
@@ -495,7 +495,7 @@ public class VM extends CWSSimEntity {
      * of {@link Environment} and {@link StorageManager}}.
      */
     public double getPredictedReleaseTime(StorageManager sm, Environment env) {
-        final List<Double> taskRuntimes = new ArrayList<>();
+        final List<Double> taskRuntimes = new ArrayList<Double>();
         for (final Job job : this.runningJobs) {
             taskRuntimes.add(getPredictedRemainingRuntime(job, sm, env));
         }
@@ -528,7 +528,7 @@ public class VM extends CWSSimEntity {
         if (taskRuntimes.size() < this.vmType.getCores()) {
             return 0.0;
         }
-        final PriorityQueue<Double> queue = new PriorityQueue<>();
+        final PriorityQueue<Double> queue = new PriorityQueue<Double>();
         final Iterator<Double> iterator = taskRuntimes.iterator();
         for (int i = 0; i < this.vmType.getCores(); i++) {
             queue.add(iterator.next());

--- a/src/cws/core/algorithms/StorageAwareSPSS.java
+++ b/src/cws/core/algorithms/StorageAwareSPSS.java
@@ -1,5 +1,8 @@
 package cws.core.algorithms;
 
+import java.util.HashMap;
+import java.util.List;
+
 import cws.core.cloudsim.CloudSimWrapper;
 import cws.core.dag.DAG;
 import cws.core.dag.Task;
@@ -7,9 +10,6 @@ import cws.core.dag.algorithms.CriticalPath;
 import cws.core.dag.algorithms.StorageAwareCriticalPath;
 import cws.core.dag.algorithms.TopologicalOrder;
 import cws.core.engine.Environment;
-
-import java.util.HashMap;
-import java.util.List;
 
 /**
  * Storage aware version of the SPSS algorithm.
@@ -24,14 +24,13 @@ public class StorageAwareSPSS extends SPSS {
 
     @Override
     protected CriticalPath newCriticalPath(TopologicalOrder order, HashMap<Task, Double> runtimes) {
-        return new StorageAwareCriticalPath(order, runtimes,
-                getEnvironment().getVMType(),
-                getEnvironment().getStorageManager());
+        final Environment environment = getEnvironment();
+        return new StorageAwareCriticalPath(order, runtimes, environment.getVMType(), environment);
     }
 
     @Override
     protected double getPredictedTaskRuntime(Task task) {
-        return getEnvironment().getComputationPredictedRuntime(task)
-                + getEnvironment().getStorageManager().getTotalTransferTimeEstimation(task);
+        final Environment environment = getEnvironment();
+        return environment.getComputationPredictedRuntime(task) + environment.getTotalTransferTimeEstimation(task);
     }
 }

--- a/src/cws/core/dag/algorithms/StorageAwareCriticalPath.java
+++ b/src/cws/core/dag/algorithms/StorageAwareCriticalPath.java
@@ -1,11 +1,10 @@
 package cws.core.dag.algorithms;
 
-import cws.core.core.VMType;
-import cws.core.dag.Task;
-import cws.core.storage.StorageManager;
-
 import java.util.Map;
 
+import cws.core.core.VMType;
+import cws.core.dag.Task;
+import cws.core.engine.Environment;
 
 /**
  * Storage aware version of {@link CriticalPath}.
@@ -14,19 +13,17 @@ import java.util.Map;
  */
 public class StorageAwareCriticalPath extends CriticalPath {
 
-    final private StorageManager storageManager;
+    private final Environment environment;
 
-    public StorageAwareCriticalPath(TopologicalOrder order, Map<Task, Double> runtimes,
-            VMType vmType,  StorageManager storageManager) {
+    public StorageAwareCriticalPath(TopologicalOrder order, Map<Task, Double> runtimes, VMType vmType,
+            Environment environment) {
         super(order, runtimes, vmType);
 
-        this.storageManager = storageManager;
+        this.environment = environment;
     }
-
 
     @Override
     protected double getPredictedTaskRuntime(Task task, VMType vmType) {
-        return vmType.getPredictedTaskRuntime(task)
-                + this.storageManager.getTotalTransferTimeEstimation(task);
+        return vmType.getPredictedTaskRuntime(task) + this.environment.getTotalTransferTimeEstimation(task);
     }
 }

--- a/src/cws/core/engine/Environment.java
+++ b/src/cws/core/engine/Environment.java
@@ -1,5 +1,6 @@
 package cws.core.engine;
 
+import cws.core.VM;
 import cws.core.core.VMType;
 import cws.core.dag.DAG;
 import cws.core.dag.Task;
@@ -18,11 +19,6 @@ public class Environment {
     // FIXME(mequrel): temporary encapsulation breakage for static algorithm, dynamic algorithm and provisioners
     public VMType getVMType() {
         return vmType;
-    }
-
-
-    public StorageManager getStorageManager() {
-        return storageManager;
     }
 
     /**
@@ -66,5 +62,25 @@ public class Environment {
 
     public double getDeprovisioningDelayEstimation() {
         return vmType.getDeprovisioningDelayEstimation();
+    }
+
+    public double getTotalTransferTimeEstimation(Task task) {
+        return this.storageManager.getTotalTransferTimeEstimation(task);
+    }
+
+    public double getTotalTransferTimeEstimation(final Task task, final VM vm) {
+        return this.storageManager.getTotalTransferTimeEstimation(task, vm);
+    }
+
+    public double getInputTransferTimeEstimation(Task task, VM vm) {
+        return this.storageManager.getInputTransferTimeEstimation(task, vm);
+    }
+
+    public double getOutputTransferTimeEstimation(Task task, VM vm) {
+        return this.storageManager.getOutputTransferTimeEstimation(task, vm);
+    }
+
+    public double getTotalTransferTimeEstimation(DAG dag) {
+        return this.storageManager.getTotalTransferTimeEstimation(dag);
     }
 }

--- a/src/cws/core/engine/Environment.java
+++ b/src/cws/core/engine/Environment.java
@@ -133,7 +133,7 @@ public class Environment {
     }
 
     /**
-     * Calculates time needed to transfer both input and output files of all tasks of a given DAQ
+     * Calculates time needed to transfer both input and output files of all tasks of a given DAG
      * Transfer time estimation depends on cloud's {@link StorageManager}
      * @return time as double
      */

--- a/src/cws/core/engine/Environment.java
+++ b/src/cws/core/engine/Environment.java
@@ -7,6 +7,10 @@ import cws.core.dag.Task;
 import cws.core.storage.StorageManager;
 import cws.core.storage.StorageManagerStatistics;
 
+/**
+ * Class which represents the cloud's environment. Consists of supported VMTypes (currently only one)
+ * and StorageManager which handles file transfers within the cloud.
+ */
 public class Environment {
     private final VMType vmType;
     private final StorageManager storageManager;
@@ -16,15 +20,17 @@ public class Environment {
         this.storageManager = storageManager;
     }
 
-    // FIXME(mequrel): temporary encapsulation breakage for static algorithm, dynamic algorithm and provisioners
+    /**
+     * Returns VMTypes supported by this cloud (currently only one type)
+     */
     public VMType getVMType() {
         return vmType;
     }
 
     /**
-     * Returns task's predicted runtime. It is based on vmType and storage manager. <br>
-     * Note that the estimation is trivial and may not be accurate during congestion and it doesn't include runtime
-     * variance.
+     * Returns task's predicted computation runtime. It is based on vmType.<br>
+     * Note that the estimation is trivial, may not be accurate and it doesn't include runtime variance.
+     * It's assumed that task is non-divisible into many cores and it executes on one core only.
      *
      * @return task's predicted runtime as a double
      */
@@ -32,6 +38,14 @@ public class Environment {
         return vmType.getPredictedTaskRuntime(task);
     }
 
+    /**
+     * Returns dag's predicted computation runtime. It is based on vmType.<br>
+     * Note that the estimation is trivial, may not be accurate and it doesn't include runtime variance.
+     * It's assumed that task is non-divisible into many cores and it executes on one core only.
+     * It doesn't include critical path or any such estimations.
+     *
+     * @return dag's predicted runtime as a double
+     */
     public double getComputationPredictedRuntime(DAG dag) {
         double sum = 0.0;
         for (String taskName : dag.getTasks()) {
@@ -44,42 +58,85 @@ public class Environment {
         return storageManager.getStorageManagerStatistics();
     }
 
+    /**
+     * Calculates cost or running a VM for given number of seconds
+     * @return cost as double
+     */
     public double getVMCostFor(double runtimeInSeconds) {
         return getVMType().getVMCostFor(runtimeInSeconds);
     }
 
+    /**
+     * To be removed when heterogeneous cloud is introduced
+     */
+    @Deprecated
     public double getSingleVMPrice() {
         return vmType.getPriceForBillingUnit();
     }
 
+    /**
+     * To be removed when new pricing models are introduced
+     */
+    @Deprecated
     public double getBillingTimeInSeconds() {
         return vmType.getBillingTimeInSeconds();
     }
 
+    /**
+     * Returns estimated provisioning delay of a VM.
+     */
     public double getVMProvisioningOverallDelayEstimation() {
         return vmType.getProvisioningOverallDelayEstimation();
     }
 
+    /**
+     * Returns estimated deprovisioning delay of a VM.
+     */
     public double getDeprovisioningDelayEstimation() {
         return vmType.getDeprovisioningDelayEstimation();
     }
 
+    /**
+     * Calculates time needed to transfer both input and output files of a given task.
+     * Transfer time estimation depends on cloud's {@link StorageManager}
+     * @return time as double
+     */
     public double getTotalTransferTimeEstimation(Task task) {
         return this.storageManager.getTotalTransferTimeEstimation(task);
     }
 
+    /**
+     * Calculates time needed to transfer both input and output files of a given task to and from given VM.
+     * Transfer time estimation depends on cloud's {@link StorageManager} and files currently stored in the VM.
+     * @return time as double
+     */
     public double getTotalTransferTimeEstimation(final Task task, final VM vm) {
         return this.storageManager.getTotalTransferTimeEstimation(task, vm);
     }
 
+    /**
+     * Calculates time needed to transfer input files of a given task to given VM.
+     * Transfer time estimation depends on cloud's {@link StorageManager} and files currently stored in the VM.
+     * @return time as double
+     */
     public double getInputTransferTimeEstimation(Task task, VM vm) {
         return this.storageManager.getInputTransferTimeEstimation(task, vm);
     }
 
+    /**
+     * Calculates time needed to transfer output files of a given task from given VM.
+     * Transfer time estimation depends on cloud's {@link StorageManager}.
+     * @return time as double
+     */
     public double getOutputTransferTimeEstimation(Task task, VM vm) {
         return this.storageManager.getOutputTransferTimeEstimation(task, vm);
     }
 
+    /**
+     * Calculates time needed to transfer both input and output files of all tasks of a given DAQ
+     * Transfer time estimation depends on cloud's {@link StorageManager}
+     * @return time as double
+     */
     public double getTotalTransferTimeEstimation(DAG dag) {
         return this.storageManager.getTotalTransferTimeEstimation(dag);
     }

--- a/src/cws/core/scheduler/ComputationAndTransfersRuntimePredictioner.java
+++ b/src/cws/core/scheduler/ComputationAndTransfersRuntimePredictioner.java
@@ -17,13 +17,11 @@ public final class ComputationAndTransfersRuntimePredictioner implements Runtime
 
     @Override
     public double getPredictedRuntime(Task task, VM vm) {
-        return environment.getComputationPredictedRuntime(task)
-                + environment.getStorageManager().getTotalTransferTimeEstimation(task, vm);
+        return environment.getComputationPredictedRuntime(task) + environment.getTotalTransferTimeEstimation(task, vm);
     }
 
     @Override
     public double getPredictedRuntime(DAG dag) {
-        return environment.getComputationPredictedRuntime(dag)
-                + environment.getStorageManager().getTotalTransferTimeEstimation(dag);
+        return environment.getComputationPredictedRuntime(dag) + environment.getTotalTransferTimeEstimation(dag);
     }
 }

--- a/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
+++ b/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
@@ -11,21 +11,18 @@ import cws.core.WorkflowEngine;
 import cws.core.cloudsim.CloudSimWrapper;
 import cws.core.engine.Environment;
 import cws.core.jobs.Job;
-import cws.core.storage.StorageManager;
 
 /**
  * {@link WorkflowAwareEnsembleScheduler} implementation that is also aware of the underlying storage and schedules jobs
  * to minimize file transfers.
  */
 public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicScheduler {
-    private final StorageManager storageManager;
     private final RuntimePredictioner runtimePredictioner;
     private final WorkflowAdmissioner workflowAdmissioner;
 
     public WorkflowAndLocalityAwareEnsembleScheduler(CloudSimWrapper cloudsim, Environment environment,
             RuntimePredictioner runtimePredictioner, WorkflowAdmissioner workflowAdmissioner) {
         super(cloudsim, environment);
-        this.storageManager = (StorageManager) cloudsim.getEntityByName("StorageManager");
         this.runtimePredictioner = runtimePredictioner;
         this.workflowAdmissioner = workflowAdmissioner;
     }
@@ -63,7 +60,7 @@ public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicSchedul
                 List<VM> allVms = engine.getAvailableVMs();
                 for (VM vm : allVms) {
                     if (!vm.isTerminated() && !vm.isFree()) {
-                        double t = vm.getPredictedReleaseTime(storageManager, environment);
+                        double t = vm.getPredictedReleaseTime(environment);
                         double estimatedJobFinish = runtimePredictioner.getPredictedRuntime(job.getTask(), vm) + t;
                         if (estimatedJobFinish < bestFinishTime) {
                             bestLocalVM = vm;

--- a/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
+++ b/src/cws/core/scheduler/WorkflowAndLocalityAwareEnsembleScheduler.java
@@ -1,25 +1,23 @@
 package cws.core.scheduler;
 
-import cws.core.VM;
-import cws.core.WorkflowEngine;
-import cws.core.cloudsim.CloudSimWrapper;
-import cws.core.engine.Environment;
-import cws.core.jobs.Job;
-import cws.core.storage.StorageManager;
-import cws.core.storage.cache.VMCacheManager;
-
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
+import cws.core.VM;
+import cws.core.WorkflowEngine;
+import cws.core.cloudsim.CloudSimWrapper;
+import cws.core.engine.Environment;
+import cws.core.jobs.Job;
+import cws.core.storage.StorageManager;
+
 /**
  * {@link WorkflowAwareEnsembleScheduler} implementation that is also aware of the underlying storage and schedules jobs
  * to minimize file transfers.
  */
 public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicScheduler {
-    private final VMCacheManager cacheManager;
     private final StorageManager storageManager;
     private final RuntimePredictioner runtimePredictioner;
     private final WorkflowAdmissioner workflowAdmissioner;
@@ -27,7 +25,6 @@ public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicSchedul
     public WorkflowAndLocalityAwareEnsembleScheduler(CloudSimWrapper cloudsim, Environment environment,
             RuntimePredictioner runtimePredictioner, WorkflowAdmissioner workflowAdmissioner) {
         super(cloudsim, environment);
-        this.cacheManager = (VMCacheManager) cloudsim.getEntityByName("VMCacheManager");
         this.storageManager = (StorageManager) cloudsim.getEntityByName("StorageManager");
         this.runtimePredictioner = runtimePredictioner;
         this.workflowAdmissioner = workflowAdmissioner;
@@ -66,7 +63,7 @@ public class WorkflowAndLocalityAwareEnsembleScheduler extends DAGDynamicSchedul
                 List<VM> allVms = engine.getAvailableVMs();
                 for (VM vm : allVms) {
                     if (!vm.isTerminated() && !vm.isFree()) {
-                        double t = vm.getPredictedReleaseTime(storageManager, environment, cacheManager);
+                        double t = vm.getPredictedReleaseTime(storageManager, environment);
                         double estimatedJobFinish = runtimePredictioner.getPredictedRuntime(job.getTask(), vm) + t;
                         if (estimatedJobFinish < bestFinishTime) {
                             bestLocalVM = vm;

--- a/src/cws/core/storage/StorageManager.java
+++ b/src/cws/core/storage/StorageManager.java
@@ -1,5 +1,8 @@
 package cws.core.storage;
 
+import org.cloudbus.cloudsim.core.SimEntity;
+import org.cloudbus.cloudsim.core.SimEvent;
+
 import cws.core.VM;
 import cws.core.WorkflowEvent;
 import cws.core.cloudsim.CWSSimEntity;
@@ -10,9 +13,6 @@ import cws.core.dag.DAGFile;
 import cws.core.dag.Task;
 import cws.core.exception.UnknownWorkflowEventException;
 import cws.core.jobs.Job;
-
-import org.cloudbus.cloudsim.core.SimEntity;
-import org.cloudbus.cloudsim.core.SimEvent;
 
 /**
  * Abstract class for all storage managers. It should be subclassed and implemented.
@@ -56,7 +56,7 @@ public abstract class StorageManager extends CWSSimEntity implements WorkflowEve
      * @param task - the task to estimate transfers for
      */
     public final double getOutputTransferTimeEstimation(Task task) {
-        return getTotalTransferTimeEstimation(task, null);
+        return getOutputTransferTimeEstimation(task, null);
     }
 
     /**

--- a/test/cws/core/VMTest.java
+++ b/test/cws/core/VMTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import cws.core.cloudsim.CWSSimEntity;
 import cws.core.cloudsim.CWSSimEvent;
 import cws.core.cloudsim.CloudSimWrapper;
@@ -16,9 +19,6 @@ import cws.core.engine.Environment;
 import cws.core.jobs.Job;
 import cws.core.storage.StorageManager;
 import cws.core.storage.VoidStorageManager;
-
-import org.junit.Before;
-import org.junit.Test;
 
 public class VMTest {
 
@@ -242,7 +242,7 @@ public class VMTest {
         when(sm.getTotalTransferTimeEstimation(job.getTask(), vm)).thenReturn(1.0);
         final Environment env = mock(Environment.class);
         when(env.getComputationPredictedRuntime(job.getTask())).thenReturn(2.0);
-        assertEquals(0.0, vm.getPredictedReleaseTime(sm, env, null), DELTA);
+        assertEquals(0.0, vm.getPredictedReleaseTime(sm, env), DELTA);
     }
 
     @Test
@@ -263,7 +263,7 @@ public class VMTest {
         final Environment env = mock(Environment.class);
         when(env.getComputationPredictedRuntime(job1.getTask())).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job2.getTask())).thenReturn(3.0);
-        assertEquals(8.0, vm.getPredictedReleaseTime(sm, env, null), DELTA);
+        assertEquals(8.0, vm.getPredictedReleaseTime(sm, env), DELTA);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class VMTest {
         final Environment env = mock(Environment.class);
         when(env.getComputationPredictedRuntime(job1.getTask())).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job2.getTask())).thenReturn(3.0);
-        assertEquals(3.0, vm.getPredictedReleaseTime(sm, env, null), DELTA);
+        assertEquals(3.0, vm.getPredictedReleaseTime(sm, env), DELTA);
     }
 
     @Test
@@ -315,6 +315,6 @@ public class VMTest {
             when(sm.getTotalTransferTimeEstimation(jobs[i].getTask(), vm)).thenReturn(transferTimes[i]);
             when(env.getComputationPredictedRuntime(jobs[i].getTask())).thenReturn(computationTimes[i]);
         }
-        assertEquals(5.0, vm.getPredictedReleaseTime(sm, env, null), DELTA);
+        assertEquals(5.0, vm.getPredictedReleaseTime(sm, env), DELTA);
     }
 }

--- a/test/cws/core/VMTest.java
+++ b/test/cws/core/VMTest.java
@@ -238,11 +238,10 @@ public class VMTest {
                 new DAGJob(new DAG(), 1), new Task("task_id1", "transformation", 1000), driver.getId(), this.cloudsim);
         vm.launch();
         vm.jobSubmit(job);
-        final StorageManager sm = mock(StorageManager.class);
-        when(sm.getTotalTransferTimeEstimation(job.getTask(), vm)).thenReturn(1.0);
         final Environment env = mock(Environment.class);
+        when(env.getTotalTransferTimeEstimation(job.getTask(), vm)).thenReturn(1.0);
         when(env.getComputationPredictedRuntime(job.getTask())).thenReturn(2.0);
-        assertEquals(0.0, vm.getPredictedReleaseTime(sm, env), DELTA);
+        assertEquals(0.0, vm.getPredictedReleaseTime(env), DELTA);
     }
 
     @Test
@@ -257,13 +256,12 @@ public class VMTest {
         vm.launch();
         vm.jobSubmit(job1);
         vm.jobSubmit(job2);
-        final StorageManager sm = mock(StorageManager.class);
-        when(sm.getTotalTransferTimeEstimation(job1.getTask(), vm)).thenReturn(1.0);
-        when(sm.getTotalTransferTimeEstimation(job2.getTask(), vm)).thenReturn(2.0);
         final Environment env = mock(Environment.class);
+        when(env.getTotalTransferTimeEstimation(job1.getTask(), vm)).thenReturn(1.0);
+        when(env.getTotalTransferTimeEstimation(job2.getTask(), vm)).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job1.getTask())).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job2.getTask())).thenReturn(3.0);
-        assertEquals(8.0, vm.getPredictedReleaseTime(sm, env), DELTA);
+        assertEquals(8.0, vm.getPredictedReleaseTime(env), DELTA);
     }
 
     @Test
@@ -278,13 +276,12 @@ public class VMTest {
         vm.launch();
         vm.jobSubmit(job1);
         vm.jobSubmit(job2);
-        final StorageManager sm = mock(StorageManager.class);
-        when(sm.getTotalTransferTimeEstimation(job1.getTask(), vm)).thenReturn(1.0);
-        when(sm.getTotalTransferTimeEstimation(job2.getTask(), vm)).thenReturn(2.0);
         final Environment env = mock(Environment.class);
+        when(env.getTotalTransferTimeEstimation(job1.getTask(), vm)).thenReturn(1.0);
+        when(env.getTotalTransferTimeEstimation(job2.getTask(), vm)).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job1.getTask())).thenReturn(2.0);
         when(env.getComputationPredictedRuntime(job2.getTask())).thenReturn(3.0);
-        assertEquals(3.0, vm.getPredictedReleaseTime(sm, env), DELTA);
+        assertEquals(3.0, vm.getPredictedReleaseTime(env), DELTA);
     }
 
     @Test
@@ -309,12 +306,11 @@ public class VMTest {
         }
         final double[] transferTimes = {1.0, 0.0, 1.0, 0.0, 2.0};
         final double[] computationTimes = {1.0, 2.0, 2.0, 1.0, 2.0};
-        final StorageManager sm = mock(StorageManager.class);
         final Environment env = mock(Environment.class);
         for(int i = 0; i < 5; i++) {
-            when(sm.getTotalTransferTimeEstimation(jobs[i].getTask(), vm)).thenReturn(transferTimes[i]);
+            when(env.getTotalTransferTimeEstimation(jobs[i].getTask(), vm)).thenReturn(transferTimes[i]);
             when(env.getComputationPredictedRuntime(jobs[i].getTask())).thenReturn(computationTimes[i]);
         }
-        assertEquals(5.0, vm.getPredictedReleaseTime(sm, env), DELTA);
+        assertEquals(5.0, vm.getPredictedReleaseTime(env), DELTA);
     }
 }


### PR DESCRIPTION
This PR adds transfer time estimations proxying to `Environment` Class.

Why? Because this class already handles computation time estimation and cost prediction for running a VM for a given time so let's keep things consistent.

It will be easier to develop heterogenous cloud now and add different pricing models when we keep all environment components hidden behind one class.

And by the way it adds documentation of this class and closes: https://github.com/malawski/cloudworkflowsimulator/issues/119