### PR TITLE
Read heterogeneous VM configuration

### DIFF
--- a/integration_test/cws/core/simulation/SimulationTest.java
+++ b/integration_test/cws/core/simulation/SimulationTest.java
@@ -2,6 +2,8 @@ package cws.core.simulation;
 
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -44,7 +46,7 @@ public class SimulationTest {
 
     private void mockLoadersValidReturnTypes(CommandLine args) {
         VMType vmType = VMTypeBuilder.newBuilder().mips(1.0).cores(1).price(12.0).build();
-        when(vmTypeLoader.determineVMType(args)).thenReturn(vmType);
+        when(vmTypeLoader.determineVMTypes(args)).thenReturn(Collections.singleton(vmType));
 
         GlobalStorageParams globalStorageParams = new GlobalStorageParams();
         when(globalStorageParamsLoader.determineGlobalStorageParams(args)).thenReturn(globalStorageParams);
@@ -65,7 +67,7 @@ public class SimulationTest {
         CommandLine args = validArgs.addOption("storage-manager", "global").build();
 
         mockLoadersValidReturnTypes(args);
-        when(vmTypeLoader.determineVMType(args)).thenThrow(new IllegalCWSArgumentException("invalid VMType"));
+        when(vmTypeLoader.determineVMTypes(args)).thenThrow(new IllegalCWSArgumentException("invalid VMType"));
 
         simulation.runTest(args);
     }

--- a/src/cws/core/core/VMType.java
+++ b/src/cws/core/core/VMType.java
@@ -2,6 +2,8 @@ package cws.core.core;
 
 import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
 
+import com.google.common.base.Objects;
+
 import cws.core.dag.Task;
 
 public class VMType implements Cloneable {
@@ -88,7 +90,7 @@ public class VMType implements Cloneable {
     }
 
     public VMType(double mips, int cores, double billingUnitPrice, double billingTimeInSeconds,
-                  ContinuousDistribution provisioningTime, ContinuousDistribution deprovisioningTime, long cacheSize) {
+            ContinuousDistribution provisioningTime, ContinuousDistribution deprovisioningTime, long cacheSize) {
         this.mips = mips;
         this.cores = cores;
         this.billingUnitPrice = billingUnitPrice;
@@ -96,5 +98,25 @@ public class VMType implements Cloneable {
         this.provisioningDelay = provisioningTime;
         this.deprovisioningDelay = deprovisioningTime;
         this.cacheSize = cacheSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final VMType vmType = (VMType) o;
+        return Double.compare(vmType.mips, mips) == 0 && cores == vmType.cores
+                && Double.compare(vmType.billingUnitPrice, billingUnitPrice) == 0
+                && Double.compare(vmType.billingTimeInSeconds, billingTimeInSeconds) == 0
+                && cacheSize == vmType.cacheSize && Objects.equal(provisioningDelay, vmType.provisioningDelay)
+                && Objects.equal(deprovisioningDelay, vmType.deprovisioningDelay);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(mips, cores, billingUnitPrice, billingTimeInSeconds, provisioningDelay,
+                deprovisioningDelay, cacheSize);
     }
 }

--- a/src/cws/core/core/VMTypeLoader.java
+++ b/src/cws/core/core/VMTypeLoader.java
@@ -4,7 +4,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -21,7 +23,7 @@ import cws.core.exception.IllegalCWSArgumentException;
  * loads vms/default.vm.yaml file. VM files paths should be
  * specified relatively to vms/ directory by default.
  * 
- * VM params can be overrode by CLI args like --vm-mips.
+ * VM provisioning and deprovisioning params for all VMs can be overrode by CLI args like --vm-provisioning-value.
  */
 public class VMTypeLoader {
     // explanatory constant
@@ -36,24 +38,14 @@ public class VMTypeLoader {
     static final String DEFAULT_VM_FILENAME = "default.vm.yaml";
 
     static final String VM_CACHE_SIZE_CONFIG_ENTRY = "cacheSize";
-    static final String VM_CACHE_SIZE_SHORT_OPTION_NAME = "vcs";
-    static final String VM_CACHE_SIZE_OPTION_NAME = "vm-cache-size";
 
     static final String VM_MIPS_CONFIG_ENTRY = "mips";
-    static final String VM_MIPS_SHORT_OPTION_NAME = "vmi";
-    static final String VM_MIPS_OPTION_NAME = "vm-mips";
 
     static final String VM_CORES_CONFIG_ENTRY = "cores";
-    static final String VM_CORES_SHORT_OPTION_NAME = "vco";
-    static final String VM_CORES_OPTION_NAME = "vm-cores";
 
     static final String VM_BILLING_PRICE_CONFIG_ENTRY = "unitPrice";
-    static final String VM_BILLING_PRICE_SHORT_OPTION_NAME = "vbp";
-    static final String VM_BILLING_PRICE_OPTION_NAME = "vm-billing-price";
 
     static final String VM_BILLING_TIME_CONFIG_ENTRY = "unitTime";
-    static final String VM_BILLING_UNIT_SHORT_OPTION_NAME = "vbu";
-    static final String VM_BILLING_UNIT_OPTION_NAME = "vm-billing-unit";
 
     static final String VM_PROVISIONING_DELAY_DISTRIBUTION_SHORT_OPTION_NAME = "vpd";
     static final String VM_PROVISIONING_DELAY_DISTRIBUTION_OPTION_NAME = "vm-provisioning-distribution";
@@ -121,41 +113,16 @@ public class VMTypeLoader {
 
     public static void buildCliOptions(Options options) {
         Option vmConfigDirectory = new Option(VM_CONFIGS_DIRECTORY_SHORT_OPTION_NAME, VM_CONFIGS_DIRECTORY_OPTION_NAME,
-                HAS_ARG, String.format(
-                        "VM config directory, config files are loaded relatively to its path, defaults to %s",
+                HAS_ARG,
+                String.format("VM config directory, config files are loaded relatively to its path, defaults to %s",
                         DEFAULT_VM_CONFIGS_DIRECTORY));
         vmConfigDirectory.setArgName("DIRPATH");
         options.addOption(vmConfigDirectory);
 
-        Option vm = new Option(VM_TYPE_SHORT_OPTION_NAME, VM_TYPE_OPTION_NAME, HAS_ARG, String.format(
-                "VM config filename, defaults to %s", DEFAULT_VM_FILENAME));
+        Option vm = new Option(VM_TYPE_SHORT_OPTION_NAME, VM_TYPE_OPTION_NAME, HAS_ARG,
+                String.format("VM config filename, defaults to %s", DEFAULT_VM_FILENAME));
         vm.setArgName("FILENAME");
         options.addOption(vm);
-
-        Option cacheSize = new Option(VM_CACHE_SIZE_SHORT_OPTION_NAME, VM_CACHE_SIZE_OPTION_NAME, HAS_ARG,
-                "Overrides VM cache size");
-        cacheSize.setArgName("SIZE");
-        options.addOption(cacheSize);
-
-        Option mips = new Option(VM_MIPS_SHORT_OPTION_NAME, VM_MIPS_OPTION_NAME, HAS_ARG,
-                "Overrides VM computational efficiency in mips units");
-        mips.setArgName("NUMBER");
-        options.addOption(mips);
-
-        Option cores = new Option(VM_CORES_SHORT_OPTION_NAME, VM_CORES_OPTION_NAME, HAS_ARG,
-                "Overrides VM cores number");
-        cores.setArgName("NUMBER");
-        options.addOption(cores);
-
-        Option price = new Option(VM_BILLING_PRICE_SHORT_OPTION_NAME, VM_BILLING_PRICE_OPTION_NAME, HAS_ARG,
-                "Overrides VM price per billing unit");
-        price.setArgName("PRICE");
-        options.addOption(price);
-
-        Option billingUnit = new Option(VM_BILLING_UNIT_SHORT_OPTION_NAME, VM_BILLING_UNIT_OPTION_NAME, HAS_ARG,
-                "Overrides VM billing unit in seconds");
-        billingUnit.setArgName("SECONDS");
-        options.addOption(billingUnit);
 
         Option provisioningDelayDistribution = new Option(VM_PROVISIONING_DELAY_DISTRIBUTION_SHORT_OPTION_NAME,
                 VM_PROVISIONING_DELAY_DISTRIBUTION_OPTION_NAME, HAS_ARG,
@@ -182,48 +149,27 @@ public class VMTypeLoader {
         options.addOption(deprovisioningDelayValue);
     }
 
-    public VMType determineVMType(CommandLine args) throws IllegalCWSArgumentException {
-        Map<String, Object> vmConfig = tryLoadVMFromConfigFile(args);
-        overrideConfigFromFileWithCliArgs(vmConfig, args);
-        return loadVM(vmConfig);
+    @SuppressWarnings("unchecked")
+    public Set<VMType> determineVMTypes(CommandLine args) throws IllegalCWSArgumentException {
+        final Iterable<Object> vmConfigs = tryLoadVMsFromConfigFile(args);
+        final Set<VMType> vmTypes = new HashSet<VMType>();
+        for (final Object vmConfig : vmConfigs) {
+            final Map<String, Object> configMap = (Map<String, Object>) vmConfig;
+            overrideConfigFromFileWithCliArgs(configMap, args);
+            vmTypes.add(loadVM(configMap));
+        }
+        return vmTypes;
     }
 
-    private Map<String, Object> tryLoadVMFromConfigFile(CommandLine args) {
+    private Iterable<Object> tryLoadVMsFromConfigFile(CommandLine args) {
         try {
-            return loadVMFromConfigFile(args);
+            return loadVMsFromConfigFile(args);
         } catch (FileNotFoundException e) {
-            throw new IllegalCWSArgumentException("Cannot load VM config file: " + e.getMessage());
+            throw new IllegalCWSArgumentException("Cannot load VMs config file: " + e.getMessage());
         }
     }
 
     void overrideConfigFromFileWithCliArgs(Map<String, Object> vmConfig, CommandLine args) {
-        if (args.hasOption(VM_MIPS_OPTION_NAME)) {
-            Double mips = Double.parseDouble(args.getOptionValue(VM_MIPS_OPTION_NAME));
-            vmConfig.put(VM_MIPS_CONFIG_ENTRY, mips);
-        }
-
-        if (args.hasOption(VM_CORES_OPTION_NAME)) {
-            Integer cores = Integer.parseInt(args.getOptionValue(VM_CORES_OPTION_NAME));
-            vmConfig.put(VM_CORES_CONFIG_ENTRY, cores);
-        }
-
-        if (args.hasOption(VM_CACHE_SIZE_OPTION_NAME)) {
-            Long cacheSize = Long.parseLong(args.getOptionValue(VM_CACHE_SIZE_OPTION_NAME));
-            vmConfig.put(VM_CACHE_SIZE_CONFIG_ENTRY, cacheSize);
-        }
-
-        if (args.hasOption(VM_BILLING_PRICE_OPTION_NAME)) {
-            Double billingPrice = Double.parseDouble(args.getOptionValue(VM_BILLING_PRICE_OPTION_NAME));
-            Map<String, Object> billingConfig = getBillingSection(vmConfig);
-            billingConfig.put(VM_BILLING_PRICE_CONFIG_ENTRY, billingPrice);
-        }
-
-        if (args.hasOption(VM_BILLING_UNIT_OPTION_NAME)) {
-            Double billingUnit = Double.parseDouble(args.getOptionValue(VM_BILLING_UNIT_OPTION_NAME));
-            Map<String, Object> billingConfig = getBillingSection(vmConfig);
-            billingConfig.put(VM_BILLING_TIME_CONFIG_ENTRY, billingUnit);
-        }
-
         if (args.hasOption(VM_PROVISIONING_DELAY_DISTRIBUTION_OPTION_NAME)) {
             String distributionType = args.getOptionValue(VM_PROVISIONING_DELAY_DISTRIBUTION_OPTION_NAME);
             Map<String, Object> provisioningConfig = getProvisioningSection(vmConfig);
@@ -243,8 +189,8 @@ public class VMTypeLoader {
         }
 
         if (args.hasOption(VM_DEPROVISIONING_DELAY_VALUE_OPTION_NAME)) {
-            Double distributionValue = Double.parseDouble(args
-                    .getOptionValue(VM_DEPROVISIONING_DELAY_VALUE_OPTION_NAME));
+            Double distributionValue = Double
+                    .parseDouble(args.getOptionValue(VM_DEPROVISIONING_DELAY_VALUE_OPTION_NAME));
             Map<String, Object> deprovisioningConfig = getDeprovisioningSection(vmConfig);
             deprovisioningConfig.put(DISTRIBUTION_VALUE_CONFIG_ENTRY, distributionValue);
         }
@@ -252,27 +198,26 @@ public class VMTypeLoader {
     }
 
     @SuppressWarnings("unchecked")
-	private Map<String, Object> getProvisioningSection(Map<String, Object> vmConfig) {
+    private Map<String, Object> getProvisioningSection(Map<String, Object> vmConfig) {
         return (Map<String, Object>) vmConfig.get("provisioningDelay");
     }
 
     @SuppressWarnings("unchecked")
-	private Map<String, Object> getDeprovisioningSection(Map<String, Object> config) {
+    private Map<String, Object> getDeprovisioningSection(Map<String, Object> config) {
         return (Map<String, Object>) config.get("deprovisioningDelay");
     }
 
     @SuppressWarnings("unchecked")
-	private Map<String, Object> getBillingSection(Map<String, Object> vmConfig) {
+    private Map<String, Object> getBillingSection(Map<String, Object> vmConfig) {
         return (Map<String, Object>) vmConfig.get("billing");
     }
 
-    @SuppressWarnings("unchecked")
-	private Map<String, Object> loadVMFromConfigFile(CommandLine args) throws FileNotFoundException {
+    private Iterable<Object> loadVMsFromConfigFile(CommandLine args) throws FileNotFoundException {
         String vmConfigFilename = args.getOptionValue(VM_TYPE_OPTION_NAME, DEFAULT_VM_FILENAME);
         String vmConfigDirectory = args.getOptionValue(VM_CONFIGS_DIRECTORY_OPTION_NAME, DEFAULT_VM_CONFIGS_DIRECTORY);
 
         InputStream input = new FileInputStream(new File(vmConfigDirectory, vmConfigFilename));
         Yaml yaml = new Yaml();
-        return (Map<String, Object>) yaml.load(input);
+        return yaml.loadAll(input);
     }
 }

--- a/src/cws/core/provisioner/ConstantDistribution.java
+++ b/src/cws/core/provisioner/ConstantDistribution.java
@@ -2,6 +2,8 @@ package cws.core.provisioner;
 
 import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
 
+import com.google.common.base.Objects;
+
 /**
  * @see ContinuousDistribution
  */
@@ -19,5 +21,20 @@ public class ConstantDistribution implements ContinuousDistribution {
 
     public String toString() {
         return "constant distribution, value = " + delay;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final ConstantDistribution that = (ConstantDistribution) o;
+        return Double.compare(that.delay, this.delay) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.delay);
     }
 }

--- a/src/cws/core/simulation/Simulation.java
+++ b/src/cws/core/simulation/Simulation.java
@@ -1,50 +1,28 @@
 package cws.core.simulation;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import static com.google.common.math.DoubleMath.fuzzyEquals;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 import org.apache.commons.io.IOUtils;
 import org.cloudbus.cloudsim.Log;
 
 import cws.core.VMFactory;
-import cws.core.algorithms.Algorithm;
-import cws.core.algorithms.AlgorithmStatistics;
-import cws.core.algorithms.LocalityAwareDPDS;
-import cws.core.algorithms.StorageAndLocalityAwareWADPDS;
-import cws.core.algorithms.DPDS;
-import cws.core.algorithms.SPSS;
-import cws.core.algorithms.StorageAwareSPSS;
-import cws.core.algorithms.StorageAwareWADPDS;
-import cws.core.algorithms.WADPDS;
+import cws.core.algorithms.*;
 import cws.core.cloudsim.CloudSimWrapper;
 import cws.core.config.GlobalStorageParamsLoader;
 import cws.core.core.VMType;
 import cws.core.core.VMTypeLoader;
-import cws.core.dag.DAG;
-import cws.core.dag.DAGListGenerator;
-import cws.core.dag.DAGParser;
-import cws.core.dag.DAGStats;
-import cws.core.dag.Task;
+import cws.core.dag.*;
 import cws.core.engine.Environment;
 import cws.core.engine.EnvironmentFactory;
 import cws.core.exception.IllegalCWSArgumentException;
 import cws.core.storage.StorageManagerStatistics;
 import cws.core.storage.global.GlobalStorageParams;
-
-import static com.google.common.math.DoubleMath.fuzzyEquals;
 
 public class Simulation {
 
@@ -253,7 +231,7 @@ public class Simulation {
         double maxScaling = Double.parseDouble(args.getOptionValue("max-scaling", DEFAULT_MAX_SCALING));
         double alpha = Double.parseDouble(args.getOptionValue("alpha", DEFAULT_ALPHA));
 
-        VMType vmType = vmTypeLoader.determineVMType(args);
+        VMType vmType = vmTypeLoader.determineVMTypes(args).iterator().next();
         logVMType(vmType);
 
         VMFactory.readCliOptions(args, seed);

--- a/test/cws/core/core/VMTypeLoaderCliTest.java
+++ b/test/cws/core/core/VMTypeLoaderCliTest.java
@@ -4,17 +4,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 import org.junit.Before;
 import org.junit.Test;
 
 public class VMTypeLoaderCliTest {
     private HashMap<String, Object> config;
-    private HashMap<String, Object> billingConfig;
     private HashMap<String, Object> provisioningConfig;
     private HashMap<String, Object> deprovisioningConfig;
     private VMTypeLoader vmTypeLoader;
@@ -31,12 +26,6 @@ public class VMTypeLoaderCliTest {
         config.put("mips", 1.0);
         config.put("cores", 1);
         config.put("cacheSize", 1);
-
-        billingConfig = new HashMap<String, Object>();
-        billingConfig.put("unitTime", 1.0);
-        billingConfig.put("unitPrice", 1.0);
-
-        config.put("billing", billingConfig);
 
         provisioningConfig = new HashMap<String, Object>();
         provisioningConfig.put("value", 0.0);
@@ -63,99 +52,6 @@ public class VMTypeLoaderCliTest {
         VMTypeLoader.buildCliOptions(options);
         CommandLineParser parser = new PosixParser();
         return parser.parse(options, args);
-    }
-
-    @Test
-    public void shouldEnableToOverrideCacheSize() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeOption(VMTypeLoader.VM_CACHE_SIZE_OPTION_NAME), "12345" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(12345L, config.get(VMTypeLoader.VM_CACHE_SIZE_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverrideCacheSizeWithShortOption() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeShortOption(VMTypeLoader.VM_CACHE_SIZE_SHORT_OPTION_NAME),
-                "12345" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(12345L, config.get(VMTypeLoader.VM_CACHE_SIZE_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverrideMips() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeOption(VMTypeLoader.VM_MIPS_OPTION_NAME), "1000.0" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(1000.0, config.get(VMTypeLoader.VM_MIPS_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverrideMipsWithShortOption() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeShortOption(VMTypeLoader.VM_MIPS_SHORT_OPTION_NAME), "1000.0" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(1000.0, config.get(VMTypeLoader.VM_MIPS_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverrideCores() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeOption(VMTypeLoader.VM_CORES_OPTION_NAME), "3" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(3, config.get(VMTypeLoader.VM_CORES_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverrideCoresWithShortOption() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeShortOption(VMTypeLoader.VM_CORES_SHORT_OPTION_NAME), "3" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(3, config.get(VMTypeLoader.VM_CORES_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverridePricingUnit() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeOption(VMTypeLoader.VM_BILLING_UNIT_OPTION_NAME), "30.0" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(30.0, billingConfig.get(VMTypeLoader.VM_BILLING_TIME_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverridePricingUnitWithShortOption() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeShortOption(VMTypeLoader.VM_BILLING_UNIT_SHORT_OPTION_NAME),
-                "30.0" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(30.0, billingConfig.get(VMTypeLoader.VM_BILLING_TIME_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverridePricePerUnit() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeOption(VMTypeLoader.VM_BILLING_PRICE_OPTION_NAME), "2.3" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(2.3, billingConfig.get(VMTypeLoader.VM_BILLING_PRICE_CONFIG_ENTRY));
-    }
-
-    @Test
-    public void shouldEnableToOverridePricePerUnitWithShortOption() throws ParseException {
-        CommandLine cmd = parseArgs(new String[] { makeShortOption(VMTypeLoader.VM_BILLING_PRICE_SHORT_OPTION_NAME),
-                "2.3" });
-
-        vmTypeLoader.overrideConfigFromFileWithCliArgs(config, cmd);
-
-        assertEquals(2.3, billingConfig.get(VMTypeLoader.VM_BILLING_PRICE_CONFIG_ENTRY));
     }
 
     @Test

--- a/test/test.vm.yaml
+++ b/test/test.vm.yaml
@@ -1,3 +1,4 @@
+---
 mips: 10
 cores: 3
 cacheSize: 12345
@@ -5,6 +6,23 @@ cacheSize: 12345
 billing:
     unitTime: 600.0
     unitPrice: 3.5
+
+provisioningDelay:
+    distribution: constant
+    value: 0.0
+
+deprovisioningDelay:
+    distribution: constant
+    value: 10.0
+
+---
+mips: 20
+cores: 6
+cacheSize: 6789
+
+billing:
+    unitTime: 300.0
+    unitPrice: 7.0
 
 provisioningDelay:
     distribution: constant

--- a/vms/default.vm.yaml
+++ b/vms/default.vm.yaml
@@ -1,3 +1,4 @@
+---
 mips: 1
 cores: 1
 cacheSize: 53687091200 # 50 GiB
@@ -14,3 +15,19 @@ deprovisioningDelay:
     distribution: constant
     value: 60.0
 
+---
+mips: 1
+cores: 2
+cacheSize: 53687091200 # 50 GiB
+
+billing:
+    unitTime: 3600.0
+    unitPrice: 2.0
+
+provisioningDelay:
+    distribution: constant
+    value: 120.0
+
+deprovisioningDelay:
+    distribution: constant
+    value: 60.0


### PR DESCRIPTION
Closes: https://github.com/malawski/cloudworkflowsimulator/issues/165

It also removes ability to override VM's configuration via command line parameters, because for multiple VMs in configuration it doesn't make sense any more. I only left the possibility to override provisioning/deprovisioning parameters, because they are often consistent across machines.